### PR TITLE
fix: complete arguments for each event and export the types of props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vue3-typed-js",
-  "version": "0.0.0",
+  "name": "vue3-typed-ts",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vue3-typed-js",
-      "version": "0.0.0",
+      "name": "vue3-typed-ts",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "typed.js": "^2.1.0"

--- a/packages/components/VueTypedJs/src/typed-component.config.ts
+++ b/packages/components/VueTypedJs/src/typed-component.config.ts
@@ -105,44 +105,44 @@ export const getEventHandlers = (context: ComponentPublicInstance|null, _typedCo
 
     let typedConfig = Object.assign({}, _typedConfig) as TypedOptions
 
-    typedConfig.onComplete = () => {
-        context?.$emit('onComplete')
+    typedConfig.onComplete = (...args) => {
+        context?.$emit('onComplete',...args)
     }
 
-    typedConfig.preStringTyped = () => {
-        context?.$emit('preStringTyped')
+    typedConfig.preStringTyped = (...args) => {
+        context?.$emit('preStringTyped',...args)
     }
 
-    typedConfig.onStringTyped = () => {
-        context?.$emit('onStringTyped')
+    typedConfig.onStringTyped = (...args) => {
+        context?.$emit('onStringTyped',...args)
     }
 
-    typedConfig.onLastStringBackspaced = () => {
-        context?.$emit('onLastStringBackspaced')
+    typedConfig.onLastStringBackspaced = (...args) => {
+        context?.$emit('onLastStringBackspaced',...args)
     }
 
-    typedConfig.onTypingPaused = () => {
-        context?.$emit('onTypingPaused')
+    typedConfig.onTypingPaused = (...args) => {
+        context?.$emit('onTypingPaused',...args)
     }
 
-    typedConfig.onTypingResumed = () => {
-        context?.$emit('onTypingResumed')
+    typedConfig.onTypingResumed = (...args) => {
+        context?.$emit('onTypingResumed',...args)
     }
 
-    typedConfig.onReset = () => {
-        context?.$emit('onReset')
+    typedConfig.onReset = (...args) => {
+        context?.$emit('onReset',...args)
     }
 
-    typedConfig.onStop = () => {
-        context?.$emit('onStop')
+    typedConfig.onStop = (...args) => {
+        context?.$emit('onStop',...args)
     }
 
-    typedConfig.onStart = () => {
-        context?.$emit('onStart')
+    typedConfig.onStart = (...args) => {
+        context?.$emit('onStart',...args)
     }
 
-    typedConfig.onDestroy = () => {
-        context?.$emit('onDestroy')
+    typedConfig.onDestroy = (...args) => {
+        context?.$emit('onDestroy',...args)
     }
 
     return typedConfig

--- a/packages/index.d.ts
+++ b/packages/index.d.ts
@@ -1,5 +1,7 @@
+/// <reference types="typed.js" />
 import { App } from 'vue';
 export * from "./components";
+export type { TypedOptions } from 'typed.js';
 declare const _default: {
     install: (app: App) => void;
 };

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -2,6 +2,7 @@ import { App } from 'vue';
 import components from "./components";
 
 export * from "./components";
+export type { TypedOptions } from 'typed.js';
 
 export default {
     install: (app: App) => {


### PR DESCRIPTION
All events of this component are missing parameters which making it impossible to obtain the context information when the events are triggered.

For example, the event `onStringTyped` should have two parameters, `arrayPos` and `self`, but it is missing.

```ts
// typed.js README.md

/**
 * After each string is typed
 * @param {number} arrayPos
 * @param {Typed} self
 */
onStringTyped: (arrayPos, self) => {},
```

I have completed parameters to all the events, and then exported the configuration type `TypedOptions` for this component(re export from [typed.js](https://github.com/mattboldt/typed.js/)). 